### PR TITLE
Change add client response and correct area ids

### DIFF
--- a/src/Sources/Code/Module.cpp
+++ b/src/Sources/Code/Module.cpp
@@ -165,7 +165,6 @@ void LoadEventDefinitions() {
 	fprintf(stderr, "MobiFlight: Loaded %u event defintions in total.", CodeEvents.size());
 	fprintf(stderr, "MobiFlight: Loaded %u built-in event defintions.", eventDefinition);
 	fprintf(stderr, "MobiFlight: Loaded %u user event defintions.", CodeEvents.size() - eventDefinition);
-
 }
 
 void SendResponse(const char * message, Client* client) {
@@ -180,12 +179,10 @@ void SendResponse(const char * message, Client* client) {
 	);
 }
 
-// Sends information about new client data areas as json string.
-// e.g. {"Name": "ClientName", "SimVars": 3, "Command": 4, "Response": 5}
+// Sends information that new client data areas are created.
 void SendNewClientResponse(Client* client, Client* nc) {
 	std::ostringstream oss;
-	oss << "{\"Name\": \"" << nc->Name << "\", \"SimVars\": "  << nc->DataAreaIDSimvar;
-	oss << ", \"Command\": " << nc->DataAreaIDCommand << ", \"Response\": " << nc->DataAreaIDResponse << "}";
+	oss << "MF.Clients.Add." << nc->Name << ".Finished";
 	std::string data = oss.str();
 	fprintf(stderr, "MobiFlight[%s]: SendNewClientData > %s", client->Name.c_str(), data.c_str());
 	SendResponse(data.c_str(), client);
@@ -374,8 +371,8 @@ Client* RegisterNewClient(const std::string clientName) {
 		newClient->Name = clientName;
 		newClient->ID = RegisteredClients.size();
 		newClient->DataAreaIDSimvar = 3 * newClient->ID;
-		newClient->DataAreaIDResponse = newClient->DataAreaIDSimvar + 1;
-		newClient->DataAreaIDCommand = newClient->DataAreaIDResponse + 1;
+		newClient->DataAreaIDCommand = newClient->DataAreaIDSimvar + 1;
+		newClient->DataAreaIDResponse = newClient->DataAreaIDCommand + 1;
 		newClient->DataAreaNameSimVar = newClient->Name + std::string(CLIENT_DATA_NAME_POSTFIX_SIMVAR);
 		newClient->DataAreaNameResponse = newClient->Name + std::string(CLIENT_DATA_NAME_POSTFIX_RESPONSE);
 		newClient->DataAreaNameCommand = newClient->Name + std::string(CLIENT_DATA_NAME_POSTFIX_COMMAND);


### PR DESCRIPTION
Simplify response when adding a new client. The client does not need to know the WASM internal used IDs for the ClientDataAreas.

Old Response: 
{"Name": "MyGreatClient", "SimVars": 3, "Command": 4, "Response": 5}

New Response: 
MF.Clients.Add.MyGreatClient.Finished

----------------------------------------------------

Change default DataAreaIDs for Mobiflight ClientDataAreas back to the original values. (In the end it doesn't matter, the IDs don't need to be the same on WASM and on external SimConnect client side).

Now in the PR:
SimVar = 0
Command = 1  (SimVar+1)
Response = 2   (Command+1)

Before it was by mistake:
SimVar = 0
Command = 2
Response = 1

Attached debug wasm
[MobiFlightWasmModule.zip](https://github.com/MobiFlight/MobiFlight-WASM-Module/files/8191150/MobiFlightWasmModule.zip)
.