### PR TITLE
reduce ReadSimVars() count to improve performance

### DIFF
--- a/src/Sources/Code/Module.cpp
+++ b/src/Sources/Code/Module.cpp
@@ -299,8 +299,8 @@ void ReadSimVar(SimVar &simVar, Client* client) {
 void ReadSimVars() {
 	for (auto& client : RegisteredClients) {
 		std::list<SimVar>* SimVars = &(client->SimVars);
-		//circular list, Max 5 SimVars at once
-		for (int i=0; i < 5; ++i) {
+		//circular list, Max 12 SimVars at once
+		for (int i=0; i < 12; ++i) {
 			std:advance(client->RollingClientDataReadIndex, 1);
 			if(client->RollingClientDataReadIndex == SimVars->end()){
 				client->RollingClientDataReadIndex = SimVars->begin();


### PR DESCRIPTION
proposal of issue #9 , This has been tested on device with PilotEdge.net ATC
https://x-plane.vip/quickmade/qg1k/

1. use std::list instead of std::vector, for circular iteration
2. list max 5 SimVars reading in every frame
3. VimVars clean() needs update list iterator