### PR TITLE
Add MF.Config.MAX_VARS_PER_FRAME to limit number of variables read in each frame

### DIFF
--- a/src/PackageDefinitions/mobiflight-event-module.xml
+++ b/src/PackageDefinitions/mobiflight-event-module.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<AssetPackage Version="0.5.0">
+<AssetPackage Version="0.6.0">
 	<ItemSettings>
 		<ContentType>MISC</ContentType>
 		<Title>Event Module</Title>

--- a/src/Sources/Code/Module.cpp
+++ b/src/Sources/Code/Module.cpp
@@ -26,7 +26,6 @@ const char* CLIENT_DATA_NAME_POSTFIX_COMMAND = ".Command";
 const char* CLIENT_DATA_NAME_POSTFIX_RESPONSE = ".Response";
 
 const int MOBIFLIGHT_MESSAGE_SIZE = 1024;
-const int MOBIFLIGHT_MAX_VARS_PER_FRAME_DEFAULT = 30;
 
 // This is an offset for the dynamically registered SimVars 
 // to avoid any conflicts with base IDs
@@ -35,7 +34,9 @@ uint16_t SimVarOffset = 1000;
 // For each registered client can 10000 data definition ids are reserved
 uint16_t ClientDataDefinitionIdSimVarsRange = 10000;
 
-uint16_t MOBIFLIGHT_MAX_VARS_PER_FRAME = MOBIFLIGHT_MAX_VARS_PER_FRAME_DEFAULT;
+// Maximum number of variables that are read from sim per frame, Default: 30
+// Can be set to different value via config command
+uint16_t MOBIFLIGHT_MAX_VARS_PER_FRAME = 30;
 
 // data struct for dynamically registered SimVars
 struct SimVar {

--- a/src/Sources/Code/Module.cpp
+++ b/src/Sources/Code/Module.cpp
@@ -299,8 +299,8 @@ void ReadSimVar(SimVar &simVar, Client* client) {
 void ReadSimVars() {
 	for (auto& client : RegisteredClients) {
 		std::list<SimVar>* SimVars = &(client->SimVars);
-		//circular list, Max 5 SimVars at once
-		for (int i=0; i < 5; ++i) {
+		//circular list, Max 12 SimVars at once
+		for (int i=0; i < 12; ++i) {
 			std:advance(client->RollingClientDataReadIndex, 1);
 			if(client->RollingClientDataReadIndex == SimVars->end()){
 				client->RollingClientDataReadIndex = SimVars->begin();


### PR DESCRIPTION
This is a new PR re-using the PR from here https://github.com/MobiFlight/MobiFlight-WASM-Module/pull/11

* uses std::vector instead of std::list
* `MOBIFLIGHT_MAX_VARS_PER_FRAME` has a default value of 30, but it can be set to a new value using the command `MF.Config.MAX_VARS_PER_FRAME.Set.`