### PR TITLE
Use the default mobiflight release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release-notes
+  categories:
+    - title: New Feature 🎉
+      labels:
+        - feature
+    - title: Improvement ✨
+      labels:
+        - enhancement
+    - title: Bug Fixes 🐛
+      labels:
+        - bug
+    - title: Bug Fixes (BETA) 🐛
+      labels:
+        - bug_beta
+    - title: Documentation 📚
+      labels:
+        - documentation
+    - title: Development 💻
+      labels:
+        - development    
+    - title: Other Changes ⚡
+      labels:
+        - "*"


### PR DESCRIPTION
We use the default release.yml for nicer, and consistent release notes across repositories.