### PR TITLE
WASM module won't fail with SimConnect exception

### DIFF
--- a/src/MobiFlightEventModuleProject.xml
+++ b/src/MobiFlightEventModuleProject.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Version="2" Name="MobiFlightEventModuleProject" FolderName="Packages" MetadataFolderName="PackagesMetadata">
+<Project Version="2" Name="MobiFlightEventModuleProject" FolderName="Packages" PublishingGroupFolderName="PublishingGroupsContent" MetadataFolderName="PackagesMetadata" PublishingGroupMetadataFolderName="PublishingGroupsMetadata">
 	<OutputDirectory>.</OutputDirectory>
 	<TemporaryOutputDirectory>_PackageInt</TemporaryOutputDirectory>
+	<PublishingGroupTemporaryOutputDirectory>_PublishingGroupInt</PublishingGroupTemporaryOutputDirectory>
 	<Packages>
 		<Package>PackageDefinitions\mobiflight-event-module.xml</Package>
 	</Packages>
+	<PublishingGroups/>
 </Project>
 

--- a/src/PackageDefinitions/mobiflight-event-module.xml
+++ b/src/PackageDefinitions/mobiflight-event-module.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<AssetPackage Version="0.7.1">
+<AssetPackage Version="0.7.2">
 	<ItemSettings>
 		<ContentType>MISC</ContentType>
 		<Title>Event Module</Title>

--- a/src/Sources/Code/Module.cpp
+++ b/src/Sources/Code/Module.cpp
@@ -11,7 +11,7 @@
 #include "Module.h"
 
 HANDLE g_hSimConnect;
-const char* version = "0.7.1";
+const char* version = "0.7.2";
 
 const char* ClientName = "MobiFlightWasmModule";
 const char* MobiFlightEventPrefix = "MobiFlight.";

--- a/src/Sources/Code/StandaloneModule.vcxproj
+++ b/src/Sources/Code/StandaloneModule.vcxproj
@@ -102,7 +102,7 @@ copy /Y "$(TargetDir)events*.txt" "$(SolutionDir)..\..\PackageSources\modules"</
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
       <NoEntryPoint>true</NoEntryPoint>
     </Link>
     <PostBuildEvent />


### PR DESCRIPTION
fixes #22 

- [x] compile with current SDK 0.23.1
- [x] Increase version to 0.7.2
- [x] release profile without debug

<img width="312" alt="image" src="https://github.com/MobiFlight/MobiFlight-WASM-Module/assets/86157512/c6185fac-7640-42f1-bd24-9dea2f40dd5a">
