### PR TITLE
Avoid duplicated reading RPN code execution across multiple clients

### DIFF
--- a/src/Sources/Code/Module.cpp
+++ b/src/Sources/Code/Module.cpp
@@ -476,7 +476,11 @@ void ReadSimVarFloat(ReadRPNCode &rpn) {
 	execute_calculator_code(std::string(rpn.Code).c_str(), &floatVal, nullptr, nullptr);
 
 	for (auto& simVar : rpn.SimVars) {
-		if (simVar.Value == floatVal) continue;
+		if ((simVar.Value > floatVal) && (simVar.Value - floatVal < 0.00001F)) {
+			continue;
+		} else if ((simVar.Value < floatVal) && (floatVal - simVar.Value  < 0.00001F)) {
+			continue;
+		}
 		simVar.Value = floatVal;
 
 		WriteSimVar(simVar, simVar.clint);

--- a/src/Sources/Code/Module.cpp
+++ b/src/Sources/Code/Module.cpp
@@ -87,7 +87,7 @@ struct Client {
 };
 
 // Runtime Rolling CLient Data reading Index
-uint16_t RollingClientDataReadIndex = 0;
+uint16_t RollingDataReadIndex = 0;
 
 //RPN code execution for reading values in every frame
 struct ReadRPNCode {
@@ -441,8 +441,8 @@ void ClearSimVars(Client* client) {
 	client->StringSimVars.clear();
 
 	std::cout << "MobiFlight[" << client->Name.c_str() << "]: Cleared SimVar tracking." << std::endl;
-	//client->RollingClientDataReadIndex = client->SimVars.begin();
-	RollingClientDataReadIndex = 0;
+	//client->RollingDataReadIndex = client->SimVars.begin();
+	RollingDataReadIndex = 0;
 }
 
 
@@ -500,11 +500,11 @@ void ReadSimVars() {
 	int maxVarsPerFrame = (totalSimVars < MOBIFLIGHT_MAX_VARS_PER_FRAME) ? totalSimVars : MOBIFLIGHT_MAX_VARS_PER_FRAME;
 
 	for (int i=0; i < maxVarsPerFrame; ++i) {
-		ReadSimVar(RPNCodelist.at(RollingClientDataReadIndex));
+		ReadSimVar(RPNCodelist.at(RollingDataReadIndex));
 
-		RollingClientDataReadIndex++;
-		if (RollingClientDataReadIndex >= totalSimVars)
-			RollingClientDataReadIndex = 0;
+		RollingDataReadIndex++;
+		if (RollingDataReadIndex >= totalSimVars)
+			RollingDataReadIndex = 0;
 	}
 }
 
@@ -598,7 +598,7 @@ Client* RegisterNewClient(const std::string clientName) {
 		newClient->DataDefinitionIDStringCommand = newClient->DataDefinitionIDStringResponse + 1;
 		newClient->SimVars = std::vector<SimVar>();
 		newClient->StringSimVars = std::vector<StringSimVar>();
-		RollingClientDataReadIndex = 0;
+		RollingDataReadIndex = 0;
 		newClient->DataDefinitionIdSimVarsStart = SIMVAR_OFFSET + (newClient->ID * (CLIENT_DATA_DEF_ID_SIMVAR_RANGE + CLIENT_DATA_DEF_ID_STRINGVAR_RANGE));
 		newClient->DataDefinitionIdStringVarsStart = newClient->DataDefinitionIdSimVarsStart + CLIENT_DATA_DEF_ID_SIMVAR_RANGE;
 

--- a/src/Sources/Code/Module.cpp
+++ b/src/Sources/Code/Module.cpp
@@ -439,6 +439,29 @@ void ClearSimVars(Client* client) {
 		WriteSimVar(simVar, client);
 	}
 	client->StringSimVars.clear();
+	// clear RNP code list
+	for (std::vector<ReadRPNCode>::iterator rit = RPNCodelist.begin(); rit != RPNCodelist.end();) {
+		for (std::vector<StringSimVar>::iterator it = (*rit).StringSimVars.begin(); it != (*rit).StringSimVars.end();) {
+			if ((*it).clint == client) {
+				it = (*rit).StringSimVars.erase(it);
+			} else {
+				++it;
+			}
+		}
+		for (std::vector<SimVar>::iterator sit = (*rit).SimVars.begin(); sit != (*rit).SimVars.end();) {
+			if ((*sit).clint == client) {
+				sit = (*rit).SimVars.erase(sit);
+			} else {
+				++sit;
+			}
+		}
+		//remove empty RNP code
+		if ((*rit).StringSimVars.empty() && (*rit).SimVars.empty()) {
+			rit = RPNCodelist.erase(rit);
+		} else {
+			++rit;
+		}
+	}
 
 	std::cout << "MobiFlight[" << client->Name.c_str() << "]: Cleared SimVar tracking." << std::endl;
 	//client->RollingDataReadIndex = client->SimVars.begin();
@@ -453,7 +476,7 @@ void ReadSimVarFloat(ReadRPNCode &rpn) {
 	execute_calculator_code(std::string(rpn.Code).c_str(), &floatVal, nullptr, nullptr);
 
 	for (auto& simVar : rpn.SimVars) {
-		if (simVar.Value == floatVal) return;
+		if (simVar.Value == floatVal) continue;
 		simVar.Value = floatVal;
 
 		WriteSimVar(simVar, simVar.clint);
@@ -473,7 +496,7 @@ void ReadSimVarString(ReadRPNCode &rpn) {
 	std::string stringVal = std::string(charVal, strnlen(charVal, MOBIFLIGHT_STRING_SIMVAR_VALUE_MAX_LEN));
 
 	for (auto& simVar : rpn.StringSimVars) {
-		if (simVar.Value == stringVal) return;
+		if (simVar.Value == stringVal) continue;
 		simVar.Value = stringVal;
 
 		WriteSimVar(simVar, simVar.clint);

--- a/src/Sources/Code/Module.cpp
+++ b/src/Sources/Code/Module.cpp
@@ -52,14 +52,14 @@ struct SimVar {
 	int ID;
 	int Offset;
 	float Value;
-	struct Client * clint;
+	struct Client * client;
 };
 
 struct StringSimVar {
 	int ID;
 	int Offset;
 	std::string Value;
-	struct Client * clint;
+	struct Client * client;
 };
 
 // data struct for client accessing SimVars
@@ -319,7 +319,7 @@ void RegisterFloatSimVar(const std::string code, Client* client) {
 	newSimVar.ID = SimVars->size() + client->DataDefinitionIdSimVarsStart;
 	newSimVar.Offset = SimVars->size() * (sizeof(float));
 	newSimVar.Value = 0.0F;
-	newSimVar.clint = client;
+	newSimVar.client = client;
 	SimVars->push_back(newSimVar);
 
 	//duplicated SimVar
@@ -376,7 +376,7 @@ void RegisterStringSimVar(const std::string code, Client* client) {
 	newStringSimVar.ID = StringSimVars->size() + client->DataDefinitionIdStringVarsStart;
 	newStringSimVar.Offset = StringSimVars->size() * MOBIFLIGHT_STRING_SIMVAR_VALUE_MAX_LEN;
 	newStringSimVar.Value.empty();
-	newStringSimVar.clint = client;
+	newStringSimVar.client = client;
 	StringSimVars->push_back(newStringSimVar);
 
 	//duplicated SimVar
@@ -442,14 +442,14 @@ void ClearSimVars(Client* client) {
 	// clear RNP code list
 	for (std::vector<ReadRPNCode>::iterator rit = RPNCodelist.begin(); rit != RPNCodelist.end();) {
 		for (std::vector<StringSimVar>::iterator it = (*rit).StringSimVars.begin(); it != (*rit).StringSimVars.end();) {
-			if ((*it).clint == client) {
+			if ((*it).client == client) {
 				it = (*rit).StringSimVars.erase(it);
 			} else {
 				++it;
 			}
 		}
 		for (std::vector<SimVar>::iterator sit = (*rit).SimVars.begin(); sit != (*rit).SimVars.end();) {
-			if ((*sit).clint == client) {
+			if ((*sit).client == client) {
 				sit = (*rit).SimVars.erase(sit);
 			} else {
 				++sit;
@@ -483,10 +483,10 @@ void ReadSimVarFloat(ReadRPNCode &rpn) {
 		}
 		simVar.Value = floatVal;
 
-		WriteSimVar(simVar, simVar.clint);
+		WriteSimVar(simVar, simVar.client);
 
 #if _DEBUG
-		std::cout << "MobiFlight[" << simVar.clint->Name.c_str() << "]: SimVar " << rpn.Code.c_str();
+		std::cout << "MobiFlight[" << simVar.client->Name.c_str() << "]: SimVar " << rpn.Code.c_str();
 		std::cout << " with ID " << simVar.ID << " has value " << simVar.Value << std::endl;
 #endif
 	}
@@ -503,10 +503,10 @@ void ReadSimVarString(ReadRPNCode &rpn) {
 		if (simVar.Value == stringVal) continue;
 		simVar.Value = stringVal;
 
-		WriteSimVar(simVar, simVar.clint);
+		WriteSimVar(simVar, simVar.client);
 
 #if _DEBUG
-		std::cout << "MobiFlight[" << simVar.clint->Name.c_str() << "]: StringSimVar " << rpn.Code.c_str();
+		std::cout << "MobiFlight[" << simVar.client->Name.c_str() << "]: StringSimVar " << rpn.Code.c_str();
 		std::cout << " with ID " << simVar.ID << " has value " << simVar.Value << std::endl;
 #endif
 	}


### PR DESCRIPTION
@Koseng 

While multiple clients Add(MF.SimVars.Add.xxxxRPNcodexxx) the exact same SimVars to WASM, 
From MSFS2020 perspective, it is unnecessary to execute the same RPNcode several times in each frame. This is an enhancement change to reduce FPS impact
WASM will smartly execute duplicated SimVars only once in each frame.

introduce new data  structure:

```
//RPN code execution for reading values in every frame
struct ReadRPNCode {
	std::string Code;
	int RetType; //RetType: 0:float 1:integer 2:string
	std::vector<SimVar> SimVars;
	std::vector<StringSimVar> StringSimVars;
};
```
![‎wasm ‎1](https://github.com/MobiFlight/MobiFlight-WASM-Module/assets/1320329/eedd391f-6bde-433f-a58e-2c4bc9f0cac0)

